### PR TITLE
convert to http library instead of using node-rest-request

### DIFF
--- a/lib/PolicyQuery.js
+++ b/lib/PolicyQuery.js
@@ -41,13 +41,30 @@ var PolicyQuery = function (user, js_obj) {
 
     js_obj.get_results = function () {
         return new Promise( function (resolve, reject) {
-            var Client = require('node-rest-client').Client, args = {
-                    data: js_obj.pq_data,
-                    headers: {'Content-Type': 'application/json'}
-                }, client = new Client();
-            client.post(js_obj.url, args, function (data) {
-                resolve(data);
-            }).on('error', reject);
+            var http = require(js_obj.proto), options = {
+                    protocol: js_obj.proto+':',
+                    hostname: js_obj.addr,
+                    port: js_obj.port,
+                    method: 'POST',
+                    path: js_obj.path,
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Content-Length': JSON.stringify(js_obj.pq_data).length
+                    }
+                },
+                req = http.request(options, function (res) {
+                    var body_content = '';
+                    res.setEncoding('utf8');
+                    res.on('data', function (chunk) {
+                        body_content += chunk;
+                    });
+                    res.on('end', function () {
+                        resolve(JSON.parse(body_content));
+                    });
+                }).on('error', reject);
+            req.on('error', reject);
+            req.write(JSON.stringify(js_obj.pq_data));
+            req.end();
         });
     };
 

--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
   "dependencies": {
     "crypto": "^1.0.1",
     "ejs": "^2.5.7",
+    "http": "0.0.0",
+    "https": "^1.0.0",
     "mime": "^2.0.3",
-    "node-rest-client": "^3.1.0",
     "path": "^0.12.7",
     "promise": "^8.0.1",
     "stream-multiplexer": "^1.0.2",


### PR DESCRIPTION
### Description

remove dependency for node-rest-client
### Issues Resolved

N/A
### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
